### PR TITLE
Fix segfault by non existing file

### DIFF
--- a/source/session.c
+++ b/source/session.c
@@ -21,7 +21,11 @@ Session* fe_init_session(char* filename)
     if(filename)
     {
         fe_set_filename( s, filename );
-        // Load file
+    }
+    
+    // Load file if existent
+    if(filename && access(filename, F_OK) != -1)
+    {
         fe_file_load( s );
     }
     else


### PR DESCRIPTION
If started with a non existent file, the filename will be stored and
proceeded as it was started without any argument (new file mode).