### PR TITLE
Add search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# For next release
+# Minor Release v0.5.0 (2023-07-16)
   * **Raphael Pour**
     * logging: document feature
     * **bugfix** terminal: Ignore unsupported special keys
@@ -6,7 +6,7 @@
     * screen: add line numbers
     * add highlighting
 
-*Not released yet*
+*Released by Raphael Pour <info@raphaelpour.de>*
 
 # Patch Release v0.4.2 (2021-01-28)
   * **Raphael Pour**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     * **bugfix** terminal: Ignore unsupported special keys
     * session/terminal: add HOME+END key-binding
     * screen: add line numbers
+    * add highlighting
 
 *Not released yet*
 

--- a/include/session.h
+++ b/include/session.h
@@ -30,6 +30,9 @@ typedef struct {
 
     /* Dirty flag */
     bool dirty;
+
+    /* Search needle, NULL if no search is going on */
+    char* needle;
 } Session;
 
 Session* fe_init_session( char* filename );

--- a/include/terminal.h
+++ b/include/terminal.h
@@ -130,9 +130,11 @@ int fe_get_user_input();
 
 enum KEYS {
     UNKNOWN = -1,
+    CTRL_F = 6,
     TAB = 9,
     ENTER_MAC = 10,
     ENTER = 13,
+    CTRL_R = 18,
     CTRL_S = 19,
     ESCAPE = 27,
     BACKSPACE = 127,

--- a/include/ui.h
+++ b/include/ui.h
@@ -4,5 +4,6 @@
 #include <session.h>
 
 bool fe_safe_file_dialog( Session *s );
+bool fe_search_fwd_dialog( Session *s );
 bool fe_quit_dialog( Session *s );
 #endif

--- a/source/femto.c
+++ b/source/femto.c
@@ -129,6 +129,7 @@ int main(int argc, char *argv[])
             case PAGE_UP: fe_move_page_up( session ); break;
             case PAGE_DOWN:  fe_move_page_down( session ); break;
             case CTRL_S: fe_safe_file_dialog( session ); break;
+            case CTRL_F: fe_search_fwd_dialog( session ); break;
             case UNKNOWN:
                 /* 
                  * Do nothing if there wasn't anything useful to read like

--- a/source/session.c
+++ b/source/session.c
@@ -23,6 +23,7 @@ Session* fe_init_session( char* filename )
     s->content_length = 0;
     s->line_count = 0;
     s->dirty = false;
+    s->needle = NULL;
 
 
     /* Determine terminal properties */

--- a/source/ui.c
+++ b/source/ui.c
@@ -32,6 +32,14 @@ bool fe_safe_file_dialog( Session *s )
     return true;
 }
 
+bool fe_search_fwd_dialog( Session *s )
+{
+  /* Check if a previous search is going on/ needle is already set */
+  char * needle = fe_user_prompt( s, "Needle:" );
+
+  
+}
+
 bool fe_quit_dialog( Session *s )
 {
     if( ! s->dirty ) return true;
@@ -49,8 +57,12 @@ bool fe_quit_dialog( Session *s )
     }
 }
 
-static char* fe_user_prompt( Session *s, char* prompt )
+static char* fe_user_prompt( Session *s, char* prompt)
 {
+    /* 
+     * Add pre-answer to the parameter list in order to have search dialogs
+     * with predefined needles.
+     */
     char c = 0;
     char *answer = (char*) malloc(1);
     answer[0] = '\0';


### PR DESCRIPTION
Add forward search:

- `ctrl+f`
- search dialog appears
- type in needle
- get automatically to the first result
- go to next results by pressing `ctrl+f` again
- press enter to go to result in edit mode
- press `ctrl+f` again to enter search dialog with last search term again
- press esc to end search dialog and delete search term

Bonus:
- highlight results
- `ctrl+r` for reverse search